### PR TITLE
First Pass at Image Component

### DIFF
--- a/src/components/Image/Image.scss
+++ b/src/components/Image/Image.scss
@@ -1,0 +1,29 @@
+// TODO: all colors should be using variables and inheriting from sitebranding
+.image-border{
+  background-color: #f2f8fb
+}
+.image-title{
+  padding: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.71;
+  letter-spacing: 1px;
+  color: #292b2c;
+}
+.image-block{
+  width: 100%;
+  padding: 4px;
+  box-sizing: border-box;
+}
+.image-caption{
+  padding: 4px;
+  font-size: 14px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.5;
+  letter-spacing: normal;
+  color: #292b2c;
+}

--- a/src/components/Image/index.jsx
+++ b/src/components/Image/index.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// TODO: get from site branding
+import settings from '../../data/configuration/constants';
+
+import './Image.scss';
+
+
+const Image = props => (
+  // If title or caption is an empty string or a string of whitespaces do not display an empty div
+  <span id={props.id}>
+    <div className="image-border w-100">
+      { (props.title.trim() !== '') ? <div className="image-title">{props.title} </div> : '' }
+      <img className="image-block" src={`${settings.journalsBackendBaseUrl}${props.url}`} alt={props.altText} />
+      { (props.caption.trim() !== '') ? <div className="image-caption">{props.caption} </div> : '' }
+    </div>
+  </span>
+);
+
+Image.defaultProps = {
+  altText: '',
+  caption: '',
+  title: '',
+};
+
+Image.propTypes = {
+  url: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  altText: PropTypes.string,
+  caption: PropTypes.string,
+  title: PropTypes.string,
+};
+
+export default Image;

--- a/src/components/JournalPage/index.jsx
+++ b/src/components/JournalPage/index.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../data/constants/contentTypes';
 
 import RawHTML from '../RawHTML';
+import Image from '../Image';
 
 class JournalPage extends React.Component {
   constructor(props) {
@@ -37,8 +38,13 @@ class JournalPage extends React.Component {
                   // return <XBlockVideo />
                   return <div>XBlockVideo</div>;
                 case IMAGE:
-                  // return <Image />
-                  return <div>Image</div>;
+                  // TODO: need to change id for search
+                  return (<Image
+                    url={el.value.url}
+                    id={el.id}
+                    title={el.value.title}
+                    altText={el.value.title}
+                  />);
                 default:
                   return <div>No matching component</div>;
               }


### PR DESCRIPTION
Remaining work:
- Get backend hostname from site branding and automatically append image
  relative url to it. Currently its being pulled from settings.
- The following fields should be gotten from the backend and the author
  should be able to edit them:
  - Title of image
  - alt text
  - image caption

**Image with a title and a caption**:
<img width="833" alt="title and caption" src="https://user-images.githubusercontent.com/5060285/43212724-c3ec84a8-9002-11e8-85aa-420418a6b0c2.png">

**Image with a title and no caption**:
<img width="820" alt="title no caption" src="https://user-images.githubusercontent.com/5060285/43212738-d2108804-9002-11e8-9fd8-fee4a883e79c.png">

**Image with no title or caption**:
<img width="843" alt="no title no caption" src="https://user-images.githubusercontent.com/5060285/43212758-dda88342-9002-11e8-9c0c-b382a3353eb1.png">
