### PR TITLE
Styling for Small Images

### DIFF
--- a/src/components/ImageViewer/ImageViewer.scss
+++ b/src/components/ImageViewer/ImageViewer.scss
@@ -1,8 +1,10 @@
 // TODO: all colors should be using variables and inheriting from sitebranding
 .image-border{
-  background-color: #f2f8fb
+  background-color: #f2f8fb;
+  display: inline-block;
 }
 .image-title{
+  min-width: 350px;
   padding: 4px;
   font-size: 14px;
   font-weight: 600;
@@ -13,11 +15,13 @@
   color: #292b2c;
 }
 .image-block{
-  width: 100%;
+  max-width: 100%;
+  margin: auto;
   padding: 4px;
   box-sizing: border-box;
 }
 .image-caption{
+  min-width: 350px;
   padding: 4px;
   font-size: 14px;
   font-weight: normal;
@@ -26,4 +30,11 @@
   line-height: 1.5;
   letter-spacing: normal;
   color: #292b2c;
+}
+.grow{
+  display: flex;
+  div{
+    flex-grow: 1;
+    width: 0;
+  }
 }

--- a/src/components/ImageViewer/index.jsx
+++ b/src/components/ImageViewer/index.jsx
@@ -10,12 +10,22 @@ import './ImageViewer.scss';
 const ImageViewer = props => (
   // If title or caption is an empty string or a string of whitespaces do not display an empty div
   <span id={props.spanId}>
-    <div className="image-border w-100">
-      { (props.title.trim() !== '') ? <div className="image-title">{props.title} </div> : '' }
+    <div className="image-border">
+      { (props.title.trim() !== '') ?
+        <div className="grow">
+          <div className="image-title" >{props.title} </div>
+        </div> :
+        ''
+      }
       <img className="image-block" src={`${settings.journalsBackendBaseUrl}${props.url}`} alt={props.altText} />
       { (props.caption.trim() !== '') ?
-        <div className="image-caption" dangerouslySetInnerHTML={{ __html: props.caption }} /> : // eslint-disable-line react/no-danger
-        '' }
+        /* eslint-disable react/no-danger */
+        <div className="image-caption grow">
+          <div dangerouslySetInnerHTML={{ __html: props.caption }} />
+        </div> :
+        ''
+        /* eslint-enable react/no-danger */
+      }
     </div>
   </span>
 );

--- a/src/components/JournalPage/index.jsx
+++ b/src/components/JournalPage/index.jsx
@@ -54,7 +54,7 @@ class JournalPage extends React.Component {
                   case IMAGE:
                     return (<ImageViewer
                       url={el.value.url}
-                      spanId={el.id}
+                      spanId={el.value.span_id}
                       title={el.value.title}
                       altText={el.value.title}
                       caption={el.value.caption}


### PR DESCRIPTION
- If the image is wider then the width of the main content column: the
  image, title and caption will full the width of the main content
  column (with 4 px of padding)
- If the image is narrower then the width of the main column and wider
  then 350px: The image component will be left aligned and the title and
  caption will be the same width as the image
- If the image is narrower then 350px: The image will be left aligned
  and not stretched, but the title and caption will be 350px