### PR TITLE
Tuchfarber/nest journal routing

### DIFF
--- a/src/components/JournalAboutPage/index.jsx
+++ b/src/components/JournalAboutPage/index.jsx
@@ -1,35 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 
-class JournalAboutPage extends React.Component {
-  componentDidMount() {
-    this.props.getJournal(this.props.match.params.journalId);
-  }
-
-  render() {
-    return (
-      <div className="about-page">
-        <h3>{this.props.title}</h3>
-      </div>
-    );
-  }
-}
+const JournalAboutPage = props => (
+  <div className="about-page">
+    <h3>{props.title}</h3>
+    <Link to={{ pathname: `/${props.journalId}` }}>Enter</Link>
+  </div>
+);
 
 JournalAboutPage.defaultProps = {
   title: '',
-  getJournal: () => {},
+  journalId: 0,
 };
 
 JournalAboutPage.propTypes = {
   title: PropTypes.string,
-  getJournal: PropTypes.func,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      journalId: PropTypes.string,
-    }),
-    url: PropTypes.string,
-  }).isRequired,
+  journalId: PropTypes.number,
 };
 
 

--- a/src/components/JournalPageRedirect/index.jsx
+++ b/src/components/JournalPageRedirect/index.jsx
@@ -3,36 +3,40 @@ import PropTypes from 'prop-types';
 import { Redirect } from 'react-router';
 
 
-class JournalRerouter extends React.Component {
-  componentDidMount() {
-    this.props.getJournal(this.props.match.params.journalId);
+class JournalPageRedirect extends React.Component {
+  constructor(props) {
+    super(props);
+    this.setPageUrls();
   }
-
+  componentDidUpdate() {
+    this.setPageUrls();
+  }
+  setPageUrls() {
+    this.lastVisitedPageUrl = `/${this.props.match.params.journalId}/pages/${this.props.lastVisitedPage}`;
+    this.firstJournalPageUrl = `/${this.props.match.params.journalId}/pages/${this.props.journalFirstPage}`;
+  }
   render() {
     if (this.props.siteInfoFinishedFetching && this.props.journalFinishedFetching) {
       // Only run if both the user info and journal info API calls have finished
       if (this.props.lastVisitedPage) {
         // Send user to the last page they visited if available
-        const lastVisitedPageUrl = `/${this.props.match.params.journalId}/pages/${this.props.lastVisitedPage}`;
-        return <Redirect push to={lastVisitedPageUrl} />;
+        return <Redirect push to={this.lastVisitedPageUrl} />;
       }
       // Send user to the first page in the journal
-      const firstJournalPage = `/${this.props.match.params.journalId}/pages/${this.props.journalFirstPage}`;
-      return <Redirect push to={firstJournalPage} />;
+      return <Redirect push to={this.firstJournalPageUrl} />;
     }
     return <div>Loading...</div>;
   }
 }
 
-JournalRerouter.defaultProps = {
+JournalPageRedirect.defaultProps = {
   lastVisitedPage: 0,
   journalFirstPage: 0,
-  getJournal: () => {},
   siteInfoFinishedFetching: false,
   journalFinishedFetching: false,
 };
 
-JournalRerouter.propTypes = {
+JournalPageRedirect.propTypes = {
   lastVisitedPage: PropTypes.number,
   match: PropTypes.shape({
     params: PropTypes.shape({
@@ -41,9 +45,8 @@ JournalRerouter.propTypes = {
     url: PropTypes.string,
   }).isRequired,
   journalFirstPage: PropTypes.number,
-  getJournal: PropTypes.func,
   siteInfoFinishedFetching: PropTypes.bool,
   journalFinishedFetching: PropTypes.bool,
 };
 
-export default JournalRerouter;
+export default JournalPageRedirect;

--- a/src/components/JournalRouter/index.jsx
+++ b/src/components/JournalRouter/index.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import PropTypes from 'prop-types';
+// import { Redirect } from 'react-router';
+import JournalPageRedirectContainer from '../../containers/JournalPageRedirectContainer';
+import PrivateRouteContainer from '../../containers/PrivateRouteContainer';
+import JournalAboutPageContainer from '../../containers/JournalAboutPageContainer';
+import JournalPageContainer from '../../containers/JournalPageContainer';
+
+class JournalRouter extends React.Component {
+  componentDidMount() {
+    this.props.getJournal(this.props.match.params.journalId);
+  }
+
+  componentDidUpdate(prevProps) {
+    // if journal changes
+    if (prevProps.match.params.journalId !== this.props.match.params.journalId) {
+      this.props.getJournal(this.props.match.params.journalId);
+    }
+  }
+
+  render() {
+    return (
+      <Switch>
+        <PrivateRouteContainer exact path="/:journalId" component={JournalPageRedirectContainer} />
+        <Route path="/:journalId/about" component={JournalAboutPageContainer} />
+        <PrivateRouteContainer path="/:journalId/pages/:pageId" component={JournalPageContainer} />
+      </Switch>
+    );
+  }
+}
+
+JournalRouter.defaultProps = {
+  getJournal: () => {},
+};
+
+JournalRouter.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      journalId: PropTypes.string,
+    }),
+    url: PropTypes.string,
+  }).isRequired,
+  getJournal: PropTypes.func,
+};
+
+export default JournalRouter;

--- a/src/components/MainContent/index.jsx
+++ b/src/components/MainContent/index.jsx
@@ -4,11 +4,9 @@ import { Route, Switch } from 'react-router-dom';
 import classNames from 'classnames';
 
 import IndexPage from '../../containers/IndexPage';
-import JournalPageContainer from '../../containers/JournalPageContainer';
 import JournalPreviewContainer from '../../containers/JournalPreviewContainer';
-import JournalAboutPageContainer from '../../containers/JournalAboutPageContainer';
-import JournalRerouterContainer from '../../containers/JournalRerouterContainer';
 import PrivateRouteContainer from '../../containers/PrivateRouteContainer';
+import JournalRouterContainer from '../../containers/JournalRouterContainer';
 
 
 const MainContent = (props) => {
@@ -25,9 +23,7 @@ const MainContent = (props) => {
             <Switch>
               <Route exact path="/" component={IndexPage} />
               <PrivateRouteContainer path="/preview/:previewId" component={JournalPreviewContainer} />
-              <Route path="/:journalId/about" component={JournalAboutPageContainer} />
-              <PrivateRouteContainer path="/:journalId/pages/:pageId" component={JournalPageContainer} />
-              <PrivateRouteContainer path="/:journalId" component={JournalRerouterContainer} />
+              <Route path="/:journalId" component={JournalRouterContainer} />
             </Switch>
           </main>
         </div>

--- a/src/containers/JournalAboutPageContainer/index.jsx
+++ b/src/containers/JournalAboutPageContainer/index.jsx
@@ -1,20 +1,17 @@
 import { connect } from 'react-redux';
 
 import JournalAboutPage from '../../components/JournalAboutPage';
-import fetchJournal from '../../data/actions/journal';
-
 
 const mapStateToProps = state => (
   {
     title: state.journal.title,
+    journalId: state.journal.id,
   }
 );
 
-const mapDispatchToProps = dispatch => (
-  {
-    getJournal: pageId => dispatch(fetchJournal(pageId)),
-  }
-);
+const mapDispatchToProps = () => ({
+
+});
 
 const JournalAboutPageContainer = connect(
   mapStateToProps,

--- a/src/containers/JournalPageRedirectContainer/index.jsx
+++ b/src/containers/JournalPageRedirectContainer/index.jsx
@@ -1,8 +1,7 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import JournalRerouter from '../../components/JournalRerouter';
-import fetchJournal from '../../data/actions/journal';
+import JournalPageRedirect from '../../components/JournalPageRedirect';
 
 
 const mapStateToProps = state => (
@@ -18,15 +17,13 @@ const mapStateToProps = state => (
   }
 );
 
-const mapDispatchToProps = dispatch => (
-  {
-    getJournal: pageId => dispatch(fetchJournal(pageId)),
-  }
-);
+const mapDispatchToProps = () => ({
 
-const JournalRerouterContainer = connect(
+});
+
+const JournalPageRedirectContainer = connect(
   mapStateToProps,
   mapDispatchToProps,
-)(JournalRerouter);
+)(JournalPageRedirect);
 
-export default withRouter(JournalRerouterContainer);
+export default withRouter(JournalPageRedirectContainer);

--- a/src/containers/JournalRouterContainer/index.jsx
+++ b/src/containers/JournalRouterContainer/index.jsx
@@ -1,0 +1,22 @@
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+
+import JournalRouter from '../../components/JournalRouter';
+import fetchJournal from '../../data/actions/journal';
+
+const mapStateToProps = () => ({
+
+});
+
+const mapDispatchToProps = dispatch => (
+  {
+    getJournal: pageId => dispatch(fetchJournal(pageId)),
+  }
+);
+
+const JournalRouterContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(JournalRouter);
+
+export default withRouter(JournalRouterContainer);


### PR DESCRIPTION
Adds a JournalRouter component which acts as a router before all journal-related pages. It fetches the journal, then routes to the correct rendering component. This way we can simplify the areas we need to fetch journals. This also renames JournalRerouter (a terrible name) to JournalPageRedirect to minimize confusion between JournalRouter & JournalRerouter. 