### PR TITLE
Rename journalId to journalAboutId

### DIFF
--- a/src/components/JournalAboutPage/index.jsx
+++ b/src/components/JournalAboutPage/index.jsx
@@ -6,18 +6,18 @@ import { Link } from 'react-router-dom';
 const JournalAboutPage = props => (
   <div className="about-page">
     <h3>{props.title}</h3>
-    <Link to={{ pathname: `/${props.journalId}` }}>Enter</Link>
+    <Link to={{ pathname: `/${props.journalAboutId}` }}>Enter</Link>
   </div>
 );
 
 JournalAboutPage.defaultProps = {
   title: '',
-  journalId: 0,
+  journalAboutId: 0,
 };
 
 JournalAboutPage.propTypes = {
   title: PropTypes.string,
-  journalId: PropTypes.number,
+  journalAboutId: PropTypes.number,
 };
 
 

--- a/src/components/JournalPage/index.jsx
+++ b/src/components/JournalPage/index.jsx
@@ -37,7 +37,7 @@ class JournalPage extends React.Component {
   }
 
   render() {
-    const baseUrl = !this.props.is_preview ? `/${this.props.match.params.journalId}/pages` : '';
+    const baseUrl = !this.props.is_preview ? `/${this.props.match.params.journalAboutId}/pages` : '';
     const previousPageUrl = this.props.previousPage ? `${baseUrl}/${this.props.previousPage}` : '';
     const nextPageUrl = this.props.nextPage ? `${baseUrl}/${this.props.nextPage}` : '';
     return (
@@ -109,7 +109,7 @@ JournalPage.propTypes = {
   match: PropTypes.shape({
     params: PropTypes.shape({
       pageId: PropTypes.string,
-      journalId: PropTypes.string,
+      journalAboutId: PropTypes.string,
     }),
     url: PropTypes.string,
   }).isRequired,

--- a/src/components/JournalPageRedirect/index.jsx
+++ b/src/components/JournalPageRedirect/index.jsx
@@ -12,8 +12,8 @@ class JournalPageRedirect extends React.Component {
     this.setPageUrls();
   }
   setPageUrls() {
-    this.lastVisitedPageUrl = `/${this.props.match.params.journalId}/pages/${this.props.lastVisitedPage}`;
-    this.firstJournalPageUrl = `/${this.props.match.params.journalId}/pages/${this.props.journalFirstPage}`;
+    this.lastVisitedPageUrl = `/${this.props.match.params.journalAboutId}/pages/${this.props.lastVisitedPage}`;
+    this.firstJournalPageUrl = `/${this.props.match.params.journalAboutId}/pages/${this.props.journalFirstPage}`;
   }
   render() {
     if (this.props.siteInfoFinishedFetching && this.props.journalFinishedFetching) {
@@ -40,7 +40,7 @@ JournalPageRedirect.propTypes = {
   lastVisitedPage: PropTypes.number,
   match: PropTypes.shape({
     params: PropTypes.shape({
-      journalId: PropTypes.string,
+      journalAboutId: PropTypes.string,
     }),
     url: PropTypes.string,
   }).isRequired,

--- a/src/components/JournalRouter/index.jsx
+++ b/src/components/JournalRouter/index.jsx
@@ -9,7 +9,7 @@ import JournalPageContainer from '../../containers/JournalPageContainer';
 
 class JournalRouter extends React.Component {
   componentDidMount() {
-    this.props.getJournal(this.props.match.params.journalId);
+    this.props.getJournal(this.props.match.params.journalAboutId);
     if (this.props.isAuthenticated) {
       this.props.toggleNavigationVisibility(true);
     }
@@ -17,8 +17,8 @@ class JournalRouter extends React.Component {
 
   componentDidUpdate(prevProps) {
     // if journal changes
-    if (prevProps.match.params.journalId !== this.props.match.params.journalId) {
-      this.props.getJournal(this.props.match.params.journalId);
+    if (prevProps.match.params.journalAboutId !== this.props.match.params.journalAboutId) {
+      this.props.getJournal(this.props.match.params.journalAboutId);
     }
     // if auth state changes
     if (prevProps.isAuthenticated !== this.props.isAuthenticated) {
@@ -29,9 +29,9 @@ class JournalRouter extends React.Component {
   render() {
     return (
       <Switch>
-        <PrivateRouteContainer exact path="/:journalId" component={JournalPageRedirectContainer} />
-        <Route path="/:journalId/about" component={JournalAboutPageContainer} />
-        <PrivateRouteContainer path="/:journalId/pages/:pageId" component={JournalPageContainer} />
+        <PrivateRouteContainer exact path="/:journalAboutId" component={JournalPageRedirectContainer} />
+        <Route path="/:journalAboutId/about" component={JournalAboutPageContainer} />
+        <PrivateRouteContainer path="/:journalAboutId/pages/:pageId" component={JournalPageContainer} />
       </Switch>
     );
   }
@@ -46,7 +46,7 @@ JournalRouter.defaultProps = {
 JournalRouter.propTypes = {
   match: PropTypes.shape({
     params: PropTypes.shape({
-      journalId: PropTypes.string,
+      journalAboutId: PropTypes.string,
     }),
     url: PropTypes.string,
   }).isRequired,

--- a/src/components/MainContent/index.jsx
+++ b/src/components/MainContent/index.jsx
@@ -23,7 +23,7 @@ const MainContent = (props) => {
             <Switch>
               <Route exact path="/" component={IndexPageContainer} />
               <PrivateRouteContainer path="/preview/:previewId" component={JournalPreviewContainer} />
-              <Route path="/:journalId" component={JournalRouterContainer} />
+              <Route path="/:journalAboutId" component={JournalRouterContainer} />
             </Switch>
           </main>
         </div>

--- a/src/components/TOCViewer/index.jsx
+++ b/src/components/TOCViewer/index.jsx
@@ -8,9 +8,12 @@ import './TOCViewer.scss';
 const TreeViewer = props => (
   props.structure.map(node => (
     <li>
-      <Link to={`/${props.journalId}/pages/${node.id}`}>{node.title}</Link>
+      <Link to={`/${props.journalAboutId}/pages/${node.id}`}>{node.title}</Link>
       <ul>
-        {node.children && <TreeViewer structure={node.children} journalId={props.journalId} />}
+        {
+          node.children &&
+          <TreeViewer structure={node.children} journalAboutId={props.journalAboutId} />
+        }
       </ul>
     </li>
   ))
@@ -21,7 +24,7 @@ const TOCViewer = props => (
   <div className="toc-border">
     {props.journal.title.trim() && <div className="journal-title">{props.journal.title}</div>}
     <ul>
-      <TreeViewer structure={props.journal.structure} journalId={props.journal.id} />
+      <TreeViewer structure={props.journal.structure} journalAboutId={props.journal.id} />
     </ul>
   </div>
 );

--- a/src/containers/JournalAboutPageContainer/index.jsx
+++ b/src/containers/JournalAboutPageContainer/index.jsx
@@ -5,7 +5,7 @@ import JournalAboutPage from '../../components/JournalAboutPage';
 const mapStateToProps = state => (
   {
     title: state.journal.title,
-    journalId: state.journal.id,
+    journalAboutId: state.journal.journalAboutId,
   }
 );
 

--- a/src/data/reducers/journal.js
+++ b/src/data/reducers/journal.js
@@ -26,7 +26,7 @@ const journal = (state = {
         longDescription: action.journal.long_description,
         cardImageUrl: action.journal.card_image_url,
         heroImageUrl: action.journal.hero_image_url,
-        id: action.journal.id,
+        aboutId: action.journal.id,
         structure: action.journal.structure,
       };
     case GET_JOURNAL_FAILURE:


### PR DESCRIPTION
Since a journal's ID isn't the same as a JournalAboutPage's ID, we need to fix references to journalId so we can use that in future work.