### PR TITLE
Update previews to pass newly added props to <JournalPage>

### DIFF
--- a/src/components/JournalPage/index.jsx
+++ b/src/components/JournalPage/index.jsx
@@ -129,6 +129,7 @@ JournalPage.defaultProps = {
   previousPage: null,
   is_preview: false,
   pageId: 0,
+  userId: null,
 };
 
 JournalPage.propTypes = {
@@ -155,7 +156,7 @@ JournalPage.propTypes = {
   nextPage: PropTypes.number,
   previousPage: PropTypes.number,
   is_preview: PropTypes.bool,
-  userId: PropTypes.number.isRequired,
+  userId: PropTypes.number,
   pageId: PropTypes.number,
 };
 

--- a/src/components/JournalPreview/index.jsx
+++ b/src/components/JournalPreview/index.jsx
@@ -20,6 +20,11 @@ class JournalPreview extends React.Component {
         fetchPreviewSuccess={this.props.fetchPreviewSuccess}
         is_preview
         title={this.props.title}
+        subTitle={this.props.subTitle}
+        displayLastPublishedDate={this.props.displayLastPublishedDate}
+        lastPublishedDate={this.props.lastPublishedDate}
+        author={this.props.author}
+        breadCrumbs={this.props.breadCrumbs}
         body={this.props.body}
       />
     );
@@ -28,6 +33,11 @@ class JournalPreview extends React.Component {
 
 JournalPreview.defaultProps = {
   title: '',
+  subTitle: '',
+  displayLastPublishedDate: false,
+  lastPublishedDate: '',
+  author: '',
+  breadCrumbs: [],
   body: [],
   getPreview: () => {},
   fetchPreviewSuccess: false,
@@ -35,6 +45,14 @@ JournalPreview.defaultProps = {
 
 JournalPreview.propTypes = {
   title: PropTypes.string,
+  subTitle: PropTypes.string,
+  displayLastPublishedDate: PropTypes.bool,
+  lastPublishedDate: PropTypes.string,
+  author: PropTypes.string,
+  breadCrumbs: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    title: PropTypes.string,
+  })),
   body: PropTypes.arrayOf(PropTypes.object),
   getPreview: PropTypes.func,
   match: PropTypes.shape({

--- a/src/components/JournalRouter/index.jsx
+++ b/src/components/JournalRouter/index.jsx
@@ -6,6 +6,7 @@ import JournalPageRedirectContainer from '../../containers/JournalPageRedirectCo
 import PrivateRouteContainer from '../../containers/PrivateRouteContainer';
 import JournalAboutPageContainer from '../../containers/JournalAboutPageContainer';
 import JournalPageContainer from '../../containers/JournalPageContainer';
+import JournalPreviewContainer from '../../containers/JournalPreviewContainer';
 
 class JournalRouter extends React.Component {
   componentDidMount() {
@@ -32,6 +33,7 @@ class JournalRouter extends React.Component {
         <PrivateRouteContainer exact path="/:journalAboutId" component={JournalPageRedirectContainer} />
         <Route path="/:journalAboutId/about" component={JournalAboutPageContainer} />
         <PrivateRouteContainer path="/:journalAboutId/pages/:pageId" component={JournalPageContainer} />
+        <PrivateRouteContainer path="/:journalAboutId/preview/:previewId" component={JournalPreviewContainer} />
       </Switch>
     );
   }

--- a/src/components/MainContent/index.jsx
+++ b/src/components/MainContent/index.jsx
@@ -4,7 +4,6 @@ import { Route, Switch } from 'react-router-dom';
 import classNames from 'classnames';
 
 import IndexPageContainer from '../../containers/IndexPageContainer';
-import JournalPreviewContainer from '../../containers/JournalPreviewContainer';
 import PrivateRouteContainer from '../../containers/PrivateRouteContainer';
 import JournalRouterContainer from '../../containers/JournalRouterContainer';
 import SearchPageContainer from '../../containers/SearchPageContainer';
@@ -24,7 +23,6 @@ const MainContent = (props) => {
             <Switch>
               <Route exact path="/" component={IndexPageContainer} />
               <PrivateRouteContainer path="/search" component={SearchPageContainer} />
-              <PrivateRouteContainer path="/preview/:previewId" component={JournalPreviewContainer} />
               <Route path="/:journalAboutId" component={JournalRouterContainer} />
             </Switch>
           </main>

--- a/src/containers/JournalPreviewContainer/index.jsx
+++ b/src/containers/JournalPreviewContainer/index.jsx
@@ -7,6 +7,11 @@ import fetchPreview from '../../data/actions/preview';
 const mapStateToProps = state => (
   {
     title: state.preview.page.title,
+    subTitle: state.preview.page.sub_title,
+    displayLastPublishedDate: state.preview.page.display_last_published_date,
+    lastPublishedDate: state.preview.page.last_published_at,
+    author: state.preview.page.author,
+    breadCrumbs: state.preview.page.bread_crumbs,
     body: state.preview.page.body,
     fetchPreviewSuccess: state.preview.error,
   }


### PR DESCRIPTION
This makes previews look the same as journal pages. We were missing the new fields.
Needs related journals backend PR to land as well:
https://github.com/edx/journals/pull/118