### PR TITLE
Fix Font Awesome Arrow Icons

### DIFF
--- a/src/components/BreadCrumbs/BreadCrumbs.scss
+++ b/src/components/BreadCrumbs/BreadCrumbs.scss
@@ -17,11 +17,10 @@ ul.bread-crumb-list {
     display: inline;
 
     .bread-crumb-arrow {
-      font-size: 14px;
-      font-weight: lighter;
+      font-size: 16px;
       line-height: 1.13;
-      padding-right: 5px;
-      padding-left: 5px;
+      padding-right: 10px;
+      padding-left: 10px;
       text-align: center;
       color: $light;
     }

--- a/src/components/BreadCrumbs/index.jsx
+++ b/src/components/BreadCrumbs/index.jsx
@@ -15,7 +15,7 @@ const BreadCrumbs = props => (
             <Link className="bread-crumb-link" to={`/${props.journalId}/pages/${page.id}`}>
               {page.title}
             </Link>
-            <Icon className="fa fa-chevron-right bread-crumb-arrow" hidden />
+            <Icon className="fa fa-angle-right bread-crumb-arrow" hidden />
           </li>
         ))
     }

--- a/src/components/PageNavigationButtons/PageNavigationButtons.scss
+++ b/src/components/PageNavigationButtons/PageNavigationButtons.scss
@@ -1,19 +1,23 @@
 .page-nav-btns{
   display: flex;
   justify-content: space-between;
-  a{
+  a.nav-btn {
     margin: 0px;
+    width: 122px;
   }
   .btn-label{
     display: inline-block;
-    div{
-      display: inline-block;
+    font-size: 16px;
+
+    .fa-angle-right{
+      padding-left: 10px;
     }
-    .fa-chevron-right{
-      padding-left: 8px;
+    .fa-angle-left{
+      padding-right: 10px;
     }
-    .fa-chevron-left{
-      padding-right: 8px;
+    .btn-text{
+      font-family: "Open Sans";
+      font-weight: bold;
     }
   }
 }

--- a/src/components/PageNavigationButtons/index.jsx
+++ b/src/components/PageNavigationButtons/index.jsx
@@ -7,15 +7,15 @@ import './PageNavigationButtons.scss';
 
 const PrevButtonText = () => (
   <div className="btn-label">
-    <Icon className="fa fa-chevron-left" hidden />
-    <span className="btn-text"> Previous </span>
+    <Icon className="fa fa-angle-left" hidden />
+    <span className="btn-text">Previous</span>
   </div>
 );
 
 const NextButtonText = () => (
   <div className="btn-label">
     <span className="btn-text">Next</span>
-    <Icon className="fa fa-chevron-right" hidden />
+    <Icon className="fa fa-angle-right" hidden />
   </div>
 );
 
@@ -23,24 +23,24 @@ const PageNavigationButtons = props => (
   <div className="page-nav-btns">
     {
       props.prev.trim() ?
-        <Link className="btn btn-outline-secondary" to={props.prev}>
+        <Link className="btn btn-outline-secondary nav-btn" to={props.prev}>
           {PrevButtonText()}
         </Link>
       :
         /* eslint-disable jsx-a11y/anchor-is-valid */
-        <a className="btn btn-outline-secondary disabled" aria-disabled="true">
+        <a className="btn btn-outline-secondary disabled nav-btn" aria-disabled="true">
           {PrevButtonText()}
         </a>
         /* eslint-enable jsx-a11y/anchor-is-valid */
     }
     {
       props.next.trim() ?
-        <Link className="btn btn-outline-secondary" to={props.next}>
+        <Link className="btn btn-outline-secondary nav-btn" to={props.next}>
           {NextButtonText()}
         </Link>
       :
         /* eslint-disable jsx-a11y/anchor-is-valid */
-        <a className="btn btn-outline-secondary disabled" aria-disabled="true">
+        <a className="btn btn-outline-secondary disabled nav-btn" aria-disabled="true">
           {NextButtonText()}
         </a>
         /* eslint-enable jsx-a11y/anchor-is-valid */

--- a/src/components/TOCViewer/index.jsx
+++ b/src/components/TOCViewer/index.jsx
@@ -61,8 +61,8 @@ class TreeViewer extends React.Component {
                     className={
                       classNames({
                         fa: true,
-                        'fa-chevron-down': this.state.expanded,
-                        'fa-chevron-right': !this.state.expanded,
+                        'fa-angle-down': this.state.expanded,
+                        'fa-angle-right': !this.state.expanded,
                       }).split(' ')
                     }
                   />


### PR DESCRIPTION
- Replaced 'fa-chevron' arrows with 'fa-angle' arrows in the bread
  crumbs, next/prev buttons and TOC viewer
- Also fixed width and some other small styling issues with the
  next/prev buttons