### PR TITLE
Fix Alignment Issues in TOC

### DIFF
--- a/src/components/TOCViewer/TOCViewer.scss
+++ b/src/components/TOCViewer/TOCViewer.scss
@@ -17,7 +17,7 @@
       }
 
       >span{
-        display: block;
+        display: flex;
         padding: 7px 5px;
 
         &:hover{
@@ -38,13 +38,14 @@
       button{
         box-sizing: content-box;
         height: 20px;
-        width: 20px;
+        border-radius: 2px;
         padding: 0;
-        margin-right: 12px;
+        margin-right: 10px;
         background-color: $lightest;
         color: $primary;
 
         .fa{
+          width: 20px;
           color: $deep-sea-blue;
         }
       }
@@ -56,7 +57,12 @@
   }
 
   .bullet{
-    margin-right: 12px;
+    div {
+      margin-right: 12px;
+      height: 20px;
+      width: 20px;
+      text-align: center;
+    }
   }
 
   .toc-title{

--- a/src/components/TOCViewer/index.jsx
+++ b/src/components/TOCViewer/index.jsx
@@ -69,7 +69,7 @@ class TreeViewer extends React.Component {
                 }
                 onClick={this.setExpanded}
               /> :
-              <span className="bullet">&bull;</span>
+              <span className="bullet"><div>&bull;</div></span>
           }
           <Link to={`/${this.props.journalAboutId}/pages/${this.props.node.id}`}>{this.props.node.title}</Link>
         </span>


### PR DESCRIPTION
- When the text of a tile wraps, the text now aligns with the text above
  it not the bullet or arrow icon
- The bullet and arrow icons are inline with each other consistently