### PR TITLE
Swap to redux-router and add segment support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 coverage/*
 dist/
 node_modules/
+src/data/segment.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,6 +206,11 @@
         "sanitize-html": "1.18.4"
       }
     },
+    "@redux-beacon/segment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redux-beacon/segment/-/segment-1.0.1.tgz",
+      "integrity": "sha512-vEMGsK/x0o6yC+r1Fj7aBXxbIre7GNLS4DuoivaiJGNWKPMOB3AiEMiAN9dijgUOZNXebG5AtYWIGnu1Nd2L2w=="
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -878,8 +883,7 @@
     "array-flatten": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-      "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
-      "dev": true
+      "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
     },
     "array-includes": {
       "version": "3.0.3",
@@ -11784,6 +11788,14 @@
         "lodash-es": "4.17.5",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.2.0"
+      }
+    },
+    "redux-beacon": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/redux-beacon/-/redux-beacon-2.0.3.tgz",
+      "integrity": "sha512-a0awbPHWBYYcPLJzEG/INXAfqx2zlLkjgnmgX98pBN1kzQjguxg2MfugaXxG/jWSycl9b17arRBMqw1rTpX96Q==",
+      "requires": {
+        "array-flatten": "2.1.1"
       }
     },
     "redux-devtools-extension": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "^1.0.0",
     "@edx/paragon": "^3.4.6",
+    "@redux-beacon/segment": "^1.0.0",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
@@ -38,6 +39,7 @@
     "react-router-hash-link": "^1.2.0",
     "react-router-redux": "^5.0.0-alpha.9",
     "redux": "^3.7.2",
+    "redux-beacon": "^2.0.3",
     "redux-devtools-extension": "^2.13.2",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
@@ -90,7 +92,8 @@
       "src/**/*.{js,jsx}"
     ],
     "coveragePathIgnorePatterns": [
-      "/node_modules/"
+      "/node_modules/",
+      "/src/segment.js"
     ],
     "transformIgnorePatterns": [
       "/node_modules/(?!(@edx/paragon)/).*/"

--- a/src/data/history.js
+++ b/src/data/history.js
@@ -1,0 +1,5 @@
+import createHistory from 'history/createBrowserHistory';
+
+const history = createHistory();
+
+export default history;

--- a/src/data/segment.js
+++ b/src/data/segment.js
@@ -1,0 +1,85 @@
+// The code in this file is based on the code from Segment's website:
+// https://segment.com/docs/sources/website/analytics.js/quickstart/
+
+const initAnalytics = (segmentKey) => {
+  var analytics = window.analytics = window.analytics || [];
+
+  // If the real analytics.js is already on the page return.
+  if (analytics.initialize) return;
+
+  // If the snippet was invoked already show an error.
+  if (analytics.invoked) {
+    if (window.console && console.error) {
+      console.error('Segment snippet included twice.');
+    }
+    return;
+  }
+
+  // Invoked flag, to make sure the snippet
+  // is never invoked twice.
+  analytics.invoked = true;
+
+  // A list of the methods in Analytics.js to stub.
+  analytics.methods = [
+    'trackSubmit',
+    'trackClick',
+    'trackLink',
+    'trackForm',
+    'pageview',
+    'identify',
+    'reset',
+    'group',
+    'track',
+    'ready',
+    'alias',
+    'debug',
+    'page',
+    'once',
+    'off',
+    'on'
+  ];
+
+  // Define a factory to create stubs. These are placeholders
+  // for methods in Analytics.js so that you never have to wait
+  // for it to load to actually record data. The `method` is
+  // stored as the first argument, so we can replay the data.
+  analytics.factory = function(method){
+    return function(){
+      var args = Array.prototype.slice.call(arguments);
+      args.unshift(method);
+      analytics.push(args);
+      return analytics;
+    };
+  };
+
+  // For each of our methods, generate a queueing stub.
+  for (var i = 0; i < analytics.methods.length; i++) {
+    var key = analytics.methods[i];
+    analytics[key] = analytics.factory(key);
+  }
+
+  // Define a method to load Analytics.js from our CDN,
+  // and that will be sure to only ever load it once.
+  analytics.load = function(key, options){
+    // Create an async script element based on your key.
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.async = true;
+    script.src = 'https://cdn.segment.com/analytics.js/v1/'
+      + key + '/analytics.min.js';
+
+    // Insert our script next to the first script element.
+    var first = document.getElementsByTagName('script')[0];
+    first.parentNode.insertBefore(script, first);
+    analytics._loadOptions = options;
+  };
+
+  // Add a version to keep track of what's in the wild.
+  analytics.SNIPPET_VERSION = '4.1.0';
+
+  // Load Analytics.js with your key, which will automatically
+  // load the tools you've enabled for your account. Boosh!
+  analytics.load(segmentKey);
+}
+
+export default initAnalytics

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -2,14 +2,48 @@ import { applyMiddleware, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 import { createLogger } from 'redux-logger';
+import { createMiddleware } from 'redux-beacon';
+import Segment, { identifyUser, trackEvent, trackPageView } from '@redux-beacon/segment';
+import { routerMiddleware, LOCATION_CHANGE } from 'react-router-redux';
 
+import { STARTED_SEARCHING } from './constants/actionTypes/search';
+import { GET_SITE_INFO_SUCCESS } from './constants/actionTypes/siteInfo';
+import initAnalytics from './segment';
+import history from './history';
 import reducers from './reducers';
 
 const loggerMiddleware = createLogger();
+const routerHistoryMiddleware = routerMiddleware(history);
+
+const eventsMap = {
+  [LOCATION_CHANGE]: () => {
+    if (window.analytics) {
+      trackPageView(action => ({ page: action.payload.pathname }));
+    }
+  },
+  [STARTED_SEARCHING]: trackEvent(action => ({
+    name: 'Searched',
+    properties: {
+      query: action.query,
+      operator: action.operator,
+      filter: action.filter,
+    },
+  })),
+  [GET_SITE_INFO_SUCCESS]: (action) => {
+    if (!window.analytics) {
+      initAnalytics(action.siteInfo.segment_key);
+    }
+    identifyUser(data => ({ userId: data.siteInfo.user.username }));
+  },
+};
+
+const segmentMiddleware = createMiddleware(eventsMap, Segment());
+
+const middleware = [thunkMiddleware, loggerMiddleware, routerHistoryMiddleware, segmentMiddleware];
 
 const store = createStore(
   reducers,
-  composeWithDevTools(applyMiddleware(thunkMiddleware, loggerMiddleware)),
+  composeWithDevTools(applyMiddleware(...middleware)),
 );
 
 export default store;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,9 +2,9 @@ import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Helmet } from 'react-helmet';
-import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { IntlProvider } from 'react-intl';
+import { ConnectedRouter } from 'react-router-redux';
 
 import HeaderContainer from './containers/HeaderContainer';
 import NavigationPanelContainer from './containers/NavigationPanelContainer';
@@ -12,12 +12,13 @@ import NavToggleContainer from './containers/NavToggleContainer';
 import MainContentContainer from './containers/MainContentContainer';
 import FooterContainer from './containers/FooterContainer';
 import store from './data/store';
+import history from './data/history';
 import './App.scss';
 
 
 const App = () => (
   <Provider store={store}>
-    <Router>
+    <ConnectedRouter history={history}>
       <div>
         <Helmet defaultTitle="Journals">
           <link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet" />
@@ -35,7 +36,7 @@ const App = () => (
         </div>
         <FooterContainer />
       </div>
-    </Router>
+    </ConnectedRouter>
   </Provider>
 );
 


### PR DESCRIPTION
Replaces react-router with react-redux-router and adds segment support. Relies on edx/journals#144 which adds segment_key to siteInfo API.