### PR TITLE
handle error when loading index page

### DIFF
--- a/src/components/JournalPageRedirect/index.jsx
+++ b/src/components/JournalPageRedirect/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router';
+import ErrorPage from '../ErrorPage';
 
 
 class JournalPageRedirect extends React.Component {
@@ -31,6 +32,14 @@ class JournalPageRedirect extends React.Component {
     this.journalAboutPageUrl = `/${this.props.match.params.journalAboutId}/about`;
   }
   render() {
+    if (this.props.error) {
+      return (
+        <ErrorPage
+          status={this.props.error.response && this.props.error.response.status}
+          message={this.props.error.message}
+        />
+      );
+    }
     if (
       this.props.siteInfoFinishedFetching &&
       this.props.journalFinishedFetching &&
@@ -55,6 +64,7 @@ JournalPageRedirect.defaultProps = {
   journalFinishedFetching: false,
   journalFirstPage: 0,
   journalAboutId: 0,
+  error: null,
 };
 
 JournalPageRedirect.propTypes = {
@@ -72,6 +82,7 @@ JournalPageRedirect.propTypes = {
   siteInfoFinishedFetching: PropTypes.bool,
   journalFinishedFetching: PropTypes.bool,
   journalAboutId: PropTypes.number,
+  error: PropTypes.instanceOf(Error),
 };
 
 export default JournalPageRedirect;

--- a/src/containers/JournalPageRedirectContainer/index.jsx
+++ b/src/containers/JournalPageRedirectContainer/index.jsx
@@ -11,6 +11,7 @@ const mapStateToProps = state => (
     journalFirstPage: state.journal.structure.length !== 0 ? state.journal.structure[0].id : null,
     visitedPages: state.siteInfo.visitedPages,
     journalAboutId: state.journal.journalAboutId,
+    error: state.journal.error,
   }
 );
 


### PR DESCRIPTION
We were just showing "Loading..." even if an error occurred when loading index page. For example if you type "localhost:1991/foobar" we now show 404 page and before just showed "Loading..." forever