### PR TITLE
WL-1828 | fix focus and keyboard navigation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -186,11 +186,12 @@
       }
     },
     "@edx/paragon": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-3.4.6.tgz",
-      "integrity": "sha512-FN86MgmoU41IhknIESdXZNqX1tzJ6WOH/JQMD6871KvWGezWyke8QnTboJrn6aehRDZqXu9UVkVeG1As8mPogQ==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-3.7.4.tgz",
+      "integrity": "sha512-gIThLgcPZXhMB6k48HgcMje7UK5YcjzygPs5gPXDrKIhWICvt7nLPdLeco3NEWI5wbFQ4o7E1qZ1m9pcxw9atg==",
       "requires": {
         "@edx/edx-bootstrap": "1.0.0",
+        "@sambego/storybook-styles": "1.0.0",
         "airbnb-prop-types": "2.10.0",
         "babel-polyfill": "6.26.0",
         "classnames": "2.2.5",
@@ -198,18 +199,47 @@
         "font-awesome": "4.7.0",
         "mailto-link": "1.0.0",
         "prop-types": "15.6.1",
-        "react": "16.2.0",
+        "react": "16.6.3",
         "react-dom": "16.2.0",
         "react-element-proptypes": "1.0.0",
         "react-proptype-conditional-require": "1.0.4",
         "react-responsive": "5.0.0",
         "sanitize-html": "1.18.4"
+      },
+      "dependencies": {
+        "react": {
+          "version": "16.6.3",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+          "integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
+          "requires": {
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.2",
+            "scheduler": "0.11.3"
+          },
+          "dependencies": {
+            "prop-types": {
+              "version": "15.6.2",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+              "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+              "requires": {
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            }
+          }
+        }
       }
     },
     "@redux-beacon/segment": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@redux-beacon/segment/-/segment-1.0.1.tgz",
       "integrity": "sha512-vEMGsK/x0o6yC+r1Fj7aBXxbIre7GNLS4DuoivaiJGNWKPMOB3AiEMiAN9dijgUOZNXebG5AtYWIGnu1Nd2L2w=="
+    },
+    "@sambego/storybook-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sambego/storybook-styles/-/storybook-styles-1.0.0.tgz",
+      "integrity": "sha512-n0SqZwDewUDRaStEcoNMiYy9qovaLVStsh4Gb2dc2LLiG3IIK0UXdeR1N7puVuRihJq/192uOyGPCjZ/NAteuA=="
     },
     "@sindresorhus/is": {
       "version": "0.7.0",
@@ -12906,6 +12936,15 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
+      "integrity": "sha512-i9X9VRRVZDd3xZw10NY5Z2cVMbdYg6gqFecfj79USv1CFN+YrJ3gIPRKf1qlY+Sxly4djoKdfx1T+m9dnRB8kQ==",
+      "requires": {
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
     },
     "schema-utils": {
       "version": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@edx/edx-bootstrap": "^1.0.0",
-    "@edx/paragon": "^3.4.6",
+    "@edx/paragon": "^3.7.4",
     "@redux-beacon/segment": "^1.0.0",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",

--- a/src/components/NavigationPanel/index.jsx
+++ b/src/components/NavigationPanel/index.jsx
@@ -35,7 +35,11 @@ class NavigationPanel extends React.Component {
         <div id="nav-panel" className={this.props.navPanelOpen ? 'nav-panel-open' : 'nav-panel-closed'}>
           {
             this.props.journalFinishedFetching ?
-              <TOCViewer journal={this.props.journal} currentPageId={this.props.currentPageId} /> :
+              <TOCViewer
+                journal={this.props.journal}
+                currentPageId={this.props.currentPageId}
+                navPanelOpen={this.props.navPanelOpen}
+              /> :
               'Loading...'
           }
         </div>

--- a/src/components/SiteHeader/index.jsx
+++ b/src/components/SiteHeader/index.jsx
@@ -19,6 +19,15 @@ const getCurrentPage = (pageId, aboutPageId, indexPageId) => {
 };
 
 class SiteHeader extends React.Component {
+  componentDidUpdate(prevProps) {
+    if (this.searchBar && !prevProps.finishedFetching && this.props.finishedFetching) {
+      const searchInputs = this.searchBar.getElementsByTagName('input');
+      if (searchInputs.length) {
+        searchInputs[0].focus();
+      }
+    }
+  }
+
   getEditorLink() {
     const currentPageId = getCurrentPage(
       this.props.pageId,
@@ -54,9 +63,11 @@ class SiteHeader extends React.Component {
           <div className="header-actions">
             {
               this.props.isAuthenticated &&
+              <div ref={(searchBar) => { this.searchBar = searchBar; }}>
                 <span className="d-none d-lg-inline-block">
                   <SearchBar journalId={this.props.journalId} history={this.props.history} />
                 </span>
+              </div>
             }
             {
               this.props.isAuthenticated ? (

--- a/src/components/TOCViewer/index.jsx
+++ b/src/components/TOCViewer/index.jsx
@@ -55,6 +55,7 @@ class TreeViewer extends React.Component {
           {
             this.props.node.children ?
               <Button
+                tabindex={this.props.visible ? 0 : -1}
                 aria-expanded={this.state.expanded}
                 label={
                   <Icon
@@ -71,7 +72,7 @@ class TreeViewer extends React.Component {
               /> :
               <span className="bullet"><div>&bull;</div></span>
           }
-          <Link to={`/${this.props.journalAboutId}/pages/${this.props.node.id}`}>{this.props.node.title}</Link>
+          <Link tabindex={this.props.visible ? 0 : -1} to={`/${this.props.journalAboutId}/pages/${this.props.node.id}`}>{this.props.node.title}</Link>
         </span>
         {
           this.props.node.children &&
@@ -81,6 +82,7 @@ class TreeViewer extends React.Component {
               journalAboutId={this.props.journalAboutId}
               currentPageId={this.props.currentPageId}
               expandParent={this.setExpanded}
+              visible={this.props.visible && this.state.expanded}
             />
           </ul>
         }
@@ -97,6 +99,7 @@ const TreeList = props => (
       journalAboutId={props.journalAboutId}
       currentPageId={props.currentPageId}
       expandParent={props.expandParent}
+      visible={props.visible}
     />
   ))
 );
@@ -110,6 +113,7 @@ const TOCViewer = props => (
         structure={props.journal.structure}
         journalAboutId={props.journal.journalAboutId}
         currentPageId={props.currentPageId}
+        visible={props.navPanelOpen}
       />
     </ul>
   </div>
@@ -121,6 +125,7 @@ TreeViewer.defaultProps = {
 };
 
 TreeViewer.propTypes = {
+  visible: PropTypes.bool.isRequired,
   node: PropTypes.shape({
     id: PropTypes.number,
     title: PropTypes.string,
@@ -132,6 +137,7 @@ TreeViewer.propTypes = {
 };
 
 TreeList.propTypes = {
+  visible: PropTypes.bool.isRequired,
   structure: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.number,
     title: PropTypes.string,
@@ -145,6 +151,7 @@ TOCViewer.defaultProps = {
 };
 
 TOCViewer.propTypes = {
+  navPanelOpen: PropTypes.bool.isRequired,
   journal: PropTypes.shape({
     journalAboutId: PropTypes.number,
     title: PropTypes.string,


### PR DESCRIPTION
Fix focus and keyboard navigation
==================================
TOC was accepting tab focus even when it's hidden and we were not able tell where the focus was.

Now this behaviour is fixed. TOC list items only get focus when they
expand, else they directly jump to TOC button.

Updated Paragon version with focus fix